### PR TITLE
feat: extended cache headers, removed failing step in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,6 @@ jobs:
           cache-dependency-path: |
             go.sum
 
-      - name: Tidy & Commit go.mod
-        run: |
-          go mod tidy
-
-          git add go.mod go.sum
-          git commit -m "Update go.mod go.sum [skip ci]"
-          git push
-
       - name: Commit CHANGELOG.md
         run: |
           echo "${{ needs.changelog.outputs.content }}" > CHANGELOG.md

--- a/api/v1/project.go
+++ b/api/v1/project.go
@@ -64,7 +64,9 @@ func HandleProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Add caching header for 24 hours
-	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.Header().Set("Cache-Control", "public, s-maxage=86400, max-age=86400")
+	w.Header().Set("CDN-Cache-Control", "public, s-maxage=86400, max-age=86400, stale-while-revalidate=172800")
+	w.Header().Set("Netlify-CDN-Cache-Control", "public, durable, s-maxage=86400, stale-while-revalidate=172800")
 
 	response := utils.NewJSONAPIResponse(r, data, nil)
 	response.WriteResponse(w)


### PR DESCRIPTION
This PR removes a failing step in the release workflow (committing `go.mod` and `go.sum` after `go mod tidy`).