### PR TITLE
fix: fixed glob patterns for ServiceWorker

### DIFF
--- a/workbox-config.cjs
+++ b/workbox-config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   globDirectory: 'public/',
-  globPatterns: ['**/*.{ico,svg,ttf,woff,png,avif,jpg,webp,css,js}'],
+  globPatterns: ['**/*.{ico,svg,ttf,woff,woff2,png,avif,jpg,webp,css,js}'],
   swDest: 'public/sw.js',
   swSrc: 'public/sw.js',
 };


### PR DESCRIPTION
This PR fixes the glob pattern for the ServiceWorker in order to also precache `.woff2` font files.