### PR TITLE
fix: fixed fallback fonts for Win95 theme

### DIFF
--- a/src/_styles/theme-win95.css
+++ b/src/_styles/theme-win95.css
@@ -7,9 +7,8 @@
 }
 
 [data-theme='Win95'] {
-  --font-family-heading: 'W95FA', var(--font-family-system-mono);
-  --font-family-body: 'W95FA', var(--font-family-system-mono);
-  --font-family-code: 'W95FA', var(--font-family-system-mono);
+  --font-family-heading: 'W95FA', var(--font-family-system-sans);
+  --font-family-body: 'W95FA', var(--font-family-system-sans);
 
   --fill-override: var(--color-secondary);
 }


### PR DESCRIPTION
This PR swaps the fallback font stack for the `Win95` theme from `mono` to `sans`.
Furthermore, the `--font-family-mono` variable has been removed in the theme, causing an automatic fallback to the default monospaced font stack.